### PR TITLE
Display info text on first load, update info text when user moves caret and when user flips decimal/hex addressing mode

### DIFF
--- a/HexCtrl/src/CHexCtrl.cpp
+++ b/HexCtrl/src/CHexCtrl.cpp
@@ -1404,7 +1404,7 @@ void CHexCtrl::OnInitMenuPopup(CMenu* /*pPopupMenu*/, UINT /*nIndex*/, BOOL /*bS
 		uStatus = MF_ENABLED;
 
 	//Main
-	m_menuMain.EnableMenuItem(IDM_HEXCTRL_SEARCH, fDataSet ? MF_ENABLED : MF_GRAYED);
+	m_menuMain.EnableMenuItem(IDM_HEXCTRL_SEARCH, fDataSet && (m_enDataMode == EHexDataMode::DATA_MEMORY) ? MF_ENABLED : MF_GRAYED);
 
 	//Bookmarks
 	bool fBookmarks = m_pBookmarks->HasBookmarks();

--- a/HexCtrl/src/CHexCtrl.cpp
+++ b/HexCtrl/src/CHexCtrl.cpp
@@ -3597,7 +3597,9 @@ void CHexCtrl::UpdateInfoText()
 
 		//Mutable state
 		if (!IsMutable())
-			m_wstrInfo += L"Read-only";
+			m_wstrInfo += L"RO";
+		else
+			m_wstrInfo += L"RW";
 	}
 	else
 		m_wstrInfo.clear();

--- a/HexCtrl/src/CHexCtrl.cpp
+++ b/HexCtrl/src/CHexCtrl.cpp
@@ -3589,11 +3589,15 @@ void CHexCtrl::UpdateInfoText()
 		if (m_pSelection->HasSelection())
 		{
 			if (m_fOffsetAsHex)
-				swprintf_s(wBuff, _countof(wBuff), L"Selected: 0x%llX bytes [0x%llX-0x%llX]", m_pSelection->GetSelectionSize(),  m_pSelection->GetSelectionStart(), m_pSelection->GetSelectionEnd() - 1);
+				swprintf_s(wBuff, _countof(wBuff), L"Selected: 0x%llX bytes [0x%llX-0x%llX] ", m_pSelection->GetSelectionSize(),  m_pSelection->GetSelectionStart(), m_pSelection->GetSelectionEnd() - 1);
 			else
-				swprintf_s(wBuff, _countof(wBuff), L"Selected: %llu bytes [%llu-%llu]", m_pSelection->GetSelectionSize(), m_pSelection->GetSelectionStart(), m_pSelection->GetSelectionEnd() - 1);
+				swprintf_s(wBuff, _countof(wBuff), L"Selected: %llu bytes [%llu-%llu] ", m_pSelection->GetSelectionSize(), m_pSelection->GetSelectionStart(), m_pSelection->GetSelectionEnd() - 1);
 			m_wstrInfo += wBuff;
 		}
+
+		//Mutable state
+		if (!IsMutable())
+			m_wstrInfo += L"Read-only";
 	}
 	else
 		m_wstrInfo.clear();

--- a/HexCtrl/src/CHexCtrl.cpp
+++ b/HexCtrl/src/CHexCtrl.cpp
@@ -3024,7 +3024,10 @@ void CHexCtrl::RecalcAll()
 	m_pScrollH->SetScrollSizes(m_sizeLetter.cx, rc.Width(), static_cast<ULONGLONG>(m_iFourthVertLine) + 1);
 	m_pScrollV->SetScrollPos(ullCurLineV * m_sizeLetter.cy);
 
-	RedrawWindow();
+	//Update info text area (this also calls RedrawWindow)
+	//This is useful if user has just flipped hex/decimal address mode
+	//RedrawWindow();
+	UpdateInfoText();
 	MsgWindowNotify(HEXCTRL_MSG_VIEWCHANGE);
 }
 
@@ -3704,7 +3707,9 @@ void CHexCtrl::SetCaretPos(ULONGLONG ullPos, bool fHighPart)
 	if (m_pScrollH->IsVisible() && !IsCurTextArea()) //Do not horz scroll when modifying text area (not Hex).
 		m_pScrollH->SetScrollPos(ullNewScrollH);
 
-	RedrawWindow();
+	//Update info text with new offset (this also calls RedrawWindow)
+	//RedrawWindow();
+	UpdateInfoText();
 	OnCaretPosChange(m_ullCaretPos);
 }
 

--- a/HexCtrl/src/CHexCtrl.cpp
+++ b/HexCtrl/src/CHexCtrl.cpp
@@ -3564,27 +3564,34 @@ void CHexCtrl::UpdateInfoText()
 {
 	if (IsDataSet())
 	{
-		WCHAR wBuff[128];
+		WCHAR wBuff[260];
 		m_wstrInfo.clear();
-		m_wstrInfo.reserve(128);
+		m_wstrInfo.reserve(_countof(wBuff));
+
+		//Offset/Document size
+		if (m_fOffsetAsHex)
+			swprintf_s(wBuff, _countof(wBuff), L"Offset: 0x%llX of 0x%llX; ", GetCaretPos(), m_ullDataSize-1);
+		else
+			swprintf_s(wBuff, _countof(wBuff), L"Offset: %llu of %llu; ", GetCaretPos(), m_ullDataSize-1);
+		m_wstrInfo = wBuff;
+		
+		//Page/Sector
 		if (IsSectorVisible())
 		{
-			swprintf_s(wBuff, 128, L"%s: %llu-%llu; ", m_wstrSectorName.data(),
-				GetCaretPos() / m_dwSectorSize, m_ullDataSize / m_dwSectorSize);
-			m_wstrInfo = wBuff;
-		}
-
-		if (m_pSelection->HasSelection())
-		{
-			swprintf_s(wBuff, 128, L"Selected: 0x%llX(%llu) [0x%llX(%llu)-0x%llX(%llu)]",
-				m_pSelection->GetSelectionSize(), m_pSelection->GetSelectionSize(),
-				m_pSelection->GetSelectionStart(), m_pSelection->GetSelectionStart(),
-				m_pSelection->GetSelectionEnd() - 1, m_pSelection->GetSelectionEnd() - 1);
+			if (m_fOffsetAsHex)
+				swprintf_s(wBuff, _countof(wBuff), L"%s: 0x%llX-0x%llX; ", m_wstrSectorName.data(), GetCaretPos() / m_dwSectorSize, m_ullDataSize / m_dwSectorSize);
+			else
+				swprintf_s(wBuff, _countof(wBuff), L"%s: %llu-%llu; ", m_wstrSectorName.data(), GetCaretPos() / m_dwSectorSize, m_ullDataSize / m_dwSectorSize);
 			m_wstrInfo += wBuff;
 		}
-		else
+
+		//Selection
+		if (m_pSelection->HasSelection())
 		{
-			swprintf_s(wBuff, 128, L"Bytes total: 0x%llX(%llu)", m_ullDataSize, m_ullDataSize);
+			if (m_fOffsetAsHex)
+				swprintf_s(wBuff, _countof(wBuff), L"Selected: 0x%llX bytes [0x%llX-0x%llX]", m_pSelection->GetSelectionSize(),  m_pSelection->GetSelectionStart(), m_pSelection->GetSelectionEnd() - 1);
+			else
+				swprintf_s(wBuff, _countof(wBuff), L"Selected: %llu bytes [%llu-%llu]", m_pSelection->GetSelectionSize(), m_pSelection->GetSelectionStart(), m_pSelection->GetSelectionEnd() - 1);
 			m_wstrInfo += wBuff;
 		}
 	}


### PR DESCRIPTION
This suggestion follows logically from showing the current offset in the info text area. My only concern is that it could impact performance slightly as the user moves the caret around with the keyboard. However, this already happens if they use the mouse so this change just makes keyboard/mouse input more consistent.