### PR TITLE
Data interpreter refinements

### DIFF
--- a/HexCtrl/src/Dialogs/CHexDlgDataInterpret.cpp
+++ b/HexCtrl/src/Dialogs/CHexDlgDataInterpret.cpp
@@ -952,8 +952,13 @@ void CHexDlgDataInterpret::ShowNAME_OLEDATETIME(QWORD qword)
 	//See: https://docs.microsoft.com/en-us/cpp/atl-mfc-shared/date-type?view=vs-2019
 
 	std::wstring wstrTime = NOTAPPLICABLE;
-	SYSTEMTIME SysTime { };
-	COleDateTime dt(static_cast<DATE>(qword));
+	
+	//Convert from ULL to Double cannot be done with static_cast?
+	DATE date;
+	std::memcpy(&date, &qword, sizeof(date));
+	COleDateTime dt(date);
+
+	SYSTEMTIME SysTime{ };
 	if (dt.GetAsSystemTime(SysTime))
 		wstrTime = SystemTimeToString(&SysTime, true, true).GetString();
 
@@ -1275,13 +1280,15 @@ bool CHexDlgDataInterpret::SetDataNAME_OLEDATETIME(std::wstring_view wstr)
 	COleDateTime dt(stTime);
 	if (dt.GetStatus() != COleDateTime::valid)
 		return false;
-
-	auto ullValue = static_cast<ULONGLONG>(dt.m_dt);
+	
+	//Cannot convert from Double to ULL with static_cast?
+	ULONGLONG ullValue;
+	std:memcpy(&ullValue, &dt.m_dt, sizeof(dt.m_dt));
 
 	if (m_fBigEndian)
 		ullValue = _byteswap_uint64(ullValue);
 
-	m_pHexCtrl->SetData(m_ullOffset, dt.m_dt);
+	m_pHexCtrl->SetData(m_ullOffset, ullValue);
 
 	return true;
 }

--- a/HexCtrl/src/Dialogs/CHexDlgDataInterpret.cpp
+++ b/HexCtrl/src/Dialogs/CHexDlgDataInterpret.cpp
@@ -1261,7 +1261,7 @@ bool CHexDlgDataInterpret::SetDataNAME_FILETIME(std::wstring_view wstr)
 	if (m_fBigEndian)
 		ullTime.QuadPart = _byteswap_uint64(ullTime.QuadPart);
 
-	m_pHexCtrl->SetData(m_ullOffset, ftTime);
+	m_pHexCtrl->SetData(m_ullOffset, ullTime.QuadPart);
 
 	return true;
 }
@@ -1335,6 +1335,8 @@ bool CHexDlgDataInterpret::SetDataNAME_MSDOSTIME(std::wstring_view wstr)
 	if (!FileTimeToDosDateTime(&ftTime, &msdosDateTime.TimeDate.wDate, &msdosDateTime.TimeDate.wTime))
 		return false;
 
+	//Note: Big Endian not currently supported. This has never existed in the "wild"
+
 	m_pHexCtrl->SetData(m_ullOffset, static_cast<DWORD>(msdosDateTime.dwTimeDate));
 
 	return true;
@@ -1355,6 +1357,8 @@ bool CHexDlgDataInterpret::SetDataNAME_MSDTTMTIME(std::wstring_view wstr)
 	dttm.components.hour = stTime.wHour;
 	dttm.components.minute = stTime.wMinute;
 
+	//Note: Big Endian not currently supported. This has never existed in the "wild"
+
 	m_pHexCtrl->SetData(m_ullOffset, static_cast<DWORD>(dttm.dwValue));
 
 	return true;
@@ -1365,6 +1369,8 @@ bool CHexDlgDataInterpret::SetDataNAME_SYSTEMTIME(std::wstring_view wstr)
 	SYSTEMTIME stTime;
 	if (!StringToSystemTime(wstr.data(), &stTime, true, true))
 		return false;
+
+	//Note: Big Endian not currently supported. This has never existed in the "wild"
 
 	m_pHexCtrl->SetData(m_ullOffset, stTime);
 

--- a/HexCtrl/src/Dialogs/CHexDlgDataInterpret.cpp
+++ b/HexCtrl/src/Dialogs/CHexDlgDataInterpret.cpp
@@ -20,6 +20,7 @@ namespace HEXCTRL::INTERNAL {
 	const WCHAR* NIBBLES [] = {
 		L"0000", L"0001", L"0010", L"0011", L"0100", L"0101", L"0110", L"0111",
 		L"1000", L"1001", L"1010", L"1011", L"1100", L"1101", L"1110", L"1111" };
+	const WCHAR NOTAPPLICABLE[] = L"N/A";
 	constexpr auto FTTICKSPERMS = 10000U;                //Number of 100ns intervals in a milli-second
 	constexpr auto FTTICKSPERSECOND = 10000000UL;        //Number of 100ns intervals in a second
 	constexpr auto HOURSPERDAY = 24U;                    //24 hours per day
@@ -543,7 +544,7 @@ CString CHexDlgDataInterpret::SystemTimeToString(const SYSTEMTIME* pSysTime, boo
 		return sResult;
 	}
 
-	return L"N/A";
+	return NOTAPPLICABLE;
 }
 
 bool CHexDlgDataInterpret::StringToSystemTime(std::wstring_view wstrDateTime, PSYSTEMTIME pSysTime, bool bIncludeDate, bool bIncludeTime)
@@ -793,7 +794,7 @@ void CHexDlgDataInterpret::ShowNAME_TIME32(DWORD dword)
 		wstrTime = StrToWstr(str);
 	}
 	else
-		wstrTime = L"N/A";
+		wstrTime = NOTAPPLICABLE;
 
 	if (auto iter = std::find_if(m_vecProp.begin(), m_vecProp.end(),
 		[](const GRIDDATA& refData) {return refData.eName == EName::NAME_TIME32T; }); iter != m_vecProp.end())
@@ -802,7 +803,7 @@ void CHexDlgDataInterpret::ShowNAME_TIME32(DWORD dword)
 
 void CHexDlgDataInterpret::ShowNAME_MSDOSTIME(DWORD dword)
 {
-	std::wstring wstrTime = L"N/A";
+	std::wstring wstrTime = NOTAPPLICABLE;
 	SYSTEMTIME SysTime { };
 	FILETIME ftMSDOS;
 	MSDOSDATETIME msdosDateTime;
@@ -821,7 +822,7 @@ void CHexDlgDataInterpret::ShowNAME_MSDOSTIME(DWORD dword)
 void CHexDlgDataInterpret::ShowNAME_MSDTTMTIME(DWORD dword)
 {
 	//Microsoft DTTM time (as used by Microsoft Compound Document format)
-	std::wstring wstrTime = L"N/A";
+	std::wstring wstrTime = NOTAPPLICABLE;
 	SYSTEMTIME SysTime { };
 	DTTM dttm;
 	dttm.dwValue = dword;
@@ -895,7 +896,7 @@ void CHexDlgDataInterpret::ShowNAME_TIME64(QWORD qword)
 		wstrTime = StrToWstr(str);
 	}
 	else
-		wstrTime = L"N/A";
+		wstrTime = NOTAPPLICABLE;
 
 	if (auto iter = std::find_if(m_vecProp.begin(), m_vecProp.end(),
 		[](const GRIDDATA& refData) {return refData.eName == EName::NAME_TIME64T; }); iter != m_vecProp.end())
@@ -904,7 +905,7 @@ void CHexDlgDataInterpret::ShowNAME_TIME64(QWORD qword)
 
 void CHexDlgDataInterpret::ShowNAME_FILETIME(QWORD qword)
 {
-	std::wstring wstrTime = L"N/A";
+	std::wstring wstrTime = NOTAPPLICABLE;
 	SYSTEMTIME SysTime { };
 	if (FileTimeToSystemTime(reinterpret_cast<const FILETIME*>(&qword), &SysTime))
 		wstrTime = SystemTimeToString(&SysTime, true, true).GetString();
@@ -920,7 +921,7 @@ void CHexDlgDataInterpret::ShowNAME_OLEDATETIME(QWORD qword)
 	//Implemented using an 8-byte floating-point number. Days are represented as whole number increments starting with 30 December 1899, midnight as time zero.
 	//See: https://docs.microsoft.com/en-us/cpp/atl-mfc-shared/date-type?view=vs-2019
 
-	std::wstring wstrTime = L"N/A";
+	std::wstring wstrTime = NOTAPPLICABLE;
 	SYSTEMTIME SysTime { };
 	COleDateTime dt(static_cast<DATE>(qword));
 	if (dt.GetAsSystemTime(SysTime))
@@ -936,7 +937,7 @@ void CHexDlgDataInterpret::ShowNAME_JAVATIME(QWORD qword)
 {
 	//Javatime (signed)
 	//Number of milliseconds after/before January 1, 1970, 00:00:00 UTC
-	std::wstring wstrTime = L"N/A";
+	std::wstring wstrTime = NOTAPPLICABLE;
 	SYSTEMTIME SysTime { };
 	FILETIME ftJavaTime;
 
@@ -975,7 +976,7 @@ void CHexDlgDataInterpret::ShowNAME_GUIDTIME(const DQWORD128 & dqword)
 	//Guid v1 Datetime UTC
 	//The time structure within the NAME_GUID.
 	//First, verify GUID is actually version 1 style
-	std::wstring wstrTime = L"N/A";
+	std::wstring wstrTime = NOTAPPLICABLE;
 	SYSTEMTIME SysTime { };
 	unsigned short unGuidVersion = (dqword.gGUID.Data3 & 0xf000) >> 12;
 

--- a/HexCtrl/src/Dialogs/CHexDlgDataInterpret.cpp
+++ b/HexCtrl/src/Dialogs/CHexDlgDataInterpret.cpp
@@ -953,9 +953,8 @@ void CHexDlgDataInterpret::ShowNAME_OLEDATETIME(QWORD qword)
 
 	std::wstring wstrTime = NOTAPPLICABLE;
 	
-	//Convert from ULL to Double cannot be done with static_cast?
-	DATE date;
-	std::memcpy(&date, &qword, sizeof(date));
+	//Interpret date (double) from raw bits
+	DATE date = *reinterpret_cast<DATE*>(&qword);
 	COleDateTime dt(date);
 
 	SYSTEMTIME SysTime{ };
@@ -1281,9 +1280,8 @@ bool CHexDlgDataInterpret::SetDataNAME_OLEDATETIME(std::wstring_view wstr)
 	if (dt.GetStatus() != COleDateTime::valid)
 		return false;
 	
-	//Cannot convert from Double to ULL with static_cast?
-	ULONGLONG ullValue;
-	std::memcpy(&ullValue, &dt.m_dt, sizeof(dt.m_dt));
+	//Treat date (double) as raw bits
+	ULONGLONG ullValue = *reinterpret_cast<ULONGLONG*>(&dt.m_dt);
 
 	if (m_fBigEndian)
 		ullValue = _byteswap_uint64(ullValue);

--- a/HexCtrl/src/Dialogs/CHexDlgDataInterpret.cpp
+++ b/HexCtrl/src/Dialogs/CHexDlgDataInterpret.cpp
@@ -1283,7 +1283,7 @@ bool CHexDlgDataInterpret::SetDataNAME_OLEDATETIME(std::wstring_view wstr)
 	
 	//Cannot convert from Double to ULL with static_cast?
 	ULONGLONG ullValue;
-	std:memcpy(&ullValue, &dt.m_dt, sizeof(dt.m_dt));
+	std::memcpy(&ullValue, &dt.m_dt, sizeof(dt.m_dt));
 
 	if (m_fBigEndian)
 		ullValue = _byteswap_uint64(ullValue);


### PR DESCRIPTION
Minor fixes for data interpreter. Mostly self-explanatory.

Some are issues that were lost in recent translation from PR and others are issues that were present in original PR.  FILETIME, OLE time, time32_t, time64_t, Javatime all checked against third-party tool and work ok. Exception is FILETIME BE which appears to not work correctly in third-party tool.

Please note use to memcpy() to workaround apparent problem converting from QWORD to Double for OLE time. Static_cast<> doesn't convert this correctly but I'm not sure why. NB: OLE time is a Double. A value of 2.0 indicates 1st January 1900.