### PR TITLE
Add search results as distinct bookmarks

### DIFF
--- a/HexCtrl/src/Dialogs/CHexDlgSearch.cpp
+++ b/HexCtrl/src/Dialogs/CHexDlgSearch.cpp
@@ -182,16 +182,17 @@ BOOL CHexDlgSearch::OnCommand(WPARAM wParam, LPARAM lParam)
 	switch (static_cast<EMenuID>(LOWORD(wParam)))
 	{
 	case EMenuID::IDM_SEARCH_ADDBKM:
-	{
-		HEXBKMSTRUCT hbs { };
+	{		
 		int nItem { -1 };
 		for (auto i = 0UL; i < m_pListMain->GetSelectedCount(); ++i)
 		{
+			HEXBKMSTRUCT hbs{ };
 			nItem = m_pListMain->GetNextItem(nItem, LVNI_SELECTED);
 			hbs.vecSpan.emplace_back(HEXSPANSTRUCT { m_vecSearchRes.at(static_cast<size_t>(nItem)),
 				m_fReplace ? m_nSizeReplace : m_nSizeSearch });
-		}
-		GetHexCtrl()->BkmAdd(hbs, true);
+
+			GetHexCtrl()->BkmAdd(hbs, true);
+		}		
 	}
 	break;
 	case EMenuID::IDM_SEARCH_SELECTALL:


### PR DESCRIPTION
Please can I suggest the following improvement. This adds the selected search results as distinct bookmarks rather than a single bookmark. 

Logic: Adding multiple search results as a single bookmark is clever but not very compatible with the other bookmark features. The bookmark manager only shows a single entry, the individual sub-spans cannot be viewed/edited in the UI and the next/previous bookmark feature doesn't work. It is probably more convenient to the user to have individual bookmarks that can be viewed and manipulated in the usual way.