### PR TITLE
Fix FILETIME search (without replace) broken

### DIFF
--- a/HexCtrl/src/Dialogs/CHexDlgSearch.cpp
+++ b/HexCtrl/src/Dialogs/CHexDlgSearch.cpp
@@ -1168,8 +1168,8 @@ bool CHexDlgSearch::PrepareFILETIME()
 		return false;
 	}
 
-	FILETIME stFTSearch { *optFTSearch };
-	FILETIME stFTReplace { optFTReplace ? *optFTReplace : FILETIME{} };
+	auto stFTSearch = *optFTSearch;
+	auto stFTReplace = optFTReplace.value_or(FILETIME { }); //optFTReplace is nullopt in RO mode.
 	if (m_fBigEndian)
 	{
 		stFTSearch.dwLowDateTime = _byteswap_ulong(stFTSearch.dwLowDateTime);

--- a/HexCtrl/src/Dialogs/CHexDlgSearch.cpp
+++ b/HexCtrl/src/Dialogs/CHexDlgSearch.cpp
@@ -1169,7 +1169,7 @@ bool CHexDlgSearch::PrepareFILETIME()
 	}
 
 	FILETIME stFTSearch { *optFTSearch };
-	FILETIME stFTReplace { *optFTReplace };
+	FILETIME stFTReplace { optFTReplace ? *optFTReplace : FILETIME{} };
 	if (m_fBigEndian)
 	{
 		stFTSearch.dwLowDateTime = _byteswap_ulong(stFTSearch.dwLowDateTime);


### PR DESCRIPTION
Small fix for FILETIME search.

To reproduce original problem:

1. Open file
2. Search (but not replace) for FILETIME e.g. "01/01/1980 02:46:30.000"

Error because existing code did not handle undefined replacement FILETIME. Other more elegant fixes may exist.